### PR TITLE
rokid-force-js-tutorial-3

### DIFF
--- a/2-RokidDocument/1-SkillsKit/rokid-force-js-tutorial.md
+++ b/2-RokidDocument/1-SkillsKit/rokid-force-js-tutorial.md
@@ -477,7 +477,7 @@ A：1、脚本允许运行时间为2s，如在2s内未完成则会超时。
 3、在调用emit及callback时请注意“上下文this”的指向。
 
 #### Q：同步请求处理总是报Unexpected token < in JSON at position 0；？
-A：开发者使用的请求地址，其返回体必须是json格式的。比如“http://xx.com/xx.html”这类地址是不可用的。
+A：开发者使用的请求地址，其返回体必须是json格式的。比如`http://xx.com/xx.html` 这类地址是不可用的。
 
 #### Q：为什么的set和emit没有起效？
 A：由于上下文this会在一定情况下改变指向，不再指向window对象，所以失去了set和emit等方法。须注意this的指向是否正确，请使用剪头函数或在函数外定义一个变量保存this即可。
@@ -485,8 +485,6 @@ A：由于上下文this会在一定情况下改变指向，不再指向window对
 #### Q：为什么request请求总是不成功？
 A：首先确保request的所有参数均正确。其次，可用postman进行请求模拟，需要严格按照postman提供的nodejs-request的请求。
 
-### 8. 1.0版本补充说明
-为保证以往技能正常运行，1.0版本将继续维护，但可能会滞后于2.0版本的更新。
-SDK-V1.0说明文档：<https://rokid.github.io/docs/2-RokidDocument/1-SkillsKit/rokid-js-engine-tutorial-v1.0.html>
+
 
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -82,8 +82,8 @@
         * [开发套件基本参数](rokidos-linux-docs/reference/dev_board/board_list.md)
         * [开发套件联网教程](rokidos-linux-docs/source/system_setting/connect_to_internet.md)
         * 编译指南
-            * [Amlogic/A113 编译指南](rokidos-linux-docs/reference/dev_board/amlogic/usermanual_a113.md)
-            * [Amlogic/S905D 编译指南](rokidos-linux-docs/reference/dev_board/amlogic/usermanual_s905d.md)
+            * [A113 ](rokidos-linux-docs/reference/dev_board/amlogic/usermanual_a113.md)
+            * [S905D ](rokidos-linux-docs/reference/dev_board/amlogic/usermanual_s905d.md)
         * [刷机教程](rokidos-linux-docs/source/downloading_building/burn_image.md)
         * [自定义激活词配置](rokidos-linux-docs/source/system_setting/custom_activation.md)
     * [RokidOS](rokidos-linux-docs/source/getting_started/overview.md)


### PR DESCRIPTION
修改了rokid-force-js-tutorial中的常见问题，将开发板里面的编译指南下拉展示中的编译指南去掉了，将技能协议改成了云端技能协议